### PR TITLE
消息摘要

### DIFF
--- a/model/message.go
+++ b/model/message.go
@@ -8,6 +8,7 @@ import (
 type Message struct {
 	AppToken    string   `json:"appToken"`
 	Content     string   `json:"content"`
+	Summary     string   `json:"summary"`
 	ContentType int      `json:"contentType"`
 	TopicIds    []int    `json:"topicIds"`
 	UIds        []string `json:"uids"`
@@ -39,7 +40,10 @@ func (m *Message) SetContent(content string) *Message {
 	m.Content = content
 	return m
 }
-
+func (m *Message) SetSummary(summary string) *Message {
+	m.Summary = summary
+	return m
+}
 func (m *Message) SetUrl(url string) *Message {
 	m.Url = url
 	return m


### PR DESCRIPTION
消息摘要，显示在微信聊天页面或者模版消息卡片上，限制长度100，可以不传，不传默认截取content前面的内容。